### PR TITLE
Handle app installation tokens for GitHub integration

### DIFF
--- a/github.go
+++ b/github.go
@@ -5,11 +5,19 @@ import (
 	"net/http/httputil"
 
 	"github.com/google/go-github/v33/github"
+	"golang.org/x/oauth2"
 	"golang.org/x/xerrors"
 
 	"github.com/gotd/td/telegram/message"
 	"github.com/gotd/td/telegram/message/styling"
 	"github.com/gotd/td/tg"
+)
+
+const (
+	githubOwner    = "gotd"
+	githubRepo     = "td"
+	githubRef      = "main"
+	githubWorkflow = "bot.yml"
 )
 
 func (b *Bot) answerGH(
@@ -24,10 +32,29 @@ func (b *Bot) answerGH(
 			return xerrors.Errorf("send: %w", err)
 		}
 	}
+
+	// Create client with short-lived repository installation token.
+	//
+	inst, _, err := gh.Apps.FindRepositoryInstallation(ctx, githubOwner, githubRepo)
+	if err != nil {
+		return xerrors.Errorf("find repository installation: %w", err)
+	}
+	tok, _, err := gh.Apps.CreateInstallationToken(ctx, inst.GetID(), nil)
+	if err != nil {
+		return xerrors.Errorf("create installation token: %w", err)
+	}
+	gh = github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{
+			AccessToken: tok.GetToken(),
+		},
+	)))
+
+	// Reply with response header.
+
 	resp, err := gh.Actions.CreateWorkflowDispatchEventByFileName(
-		ctx, "gotd", "td", "bot.yml",
+		ctx, githubOwner, githubRepo, githubWorkflow,
 		github.CreateWorkflowDispatchEventRequest{
-			Ref: "main",
+			Ref: githubRef,
 			Inputs: map[string]interface{}{
 				"telegram": true,
 				"message":  m,
@@ -37,12 +64,10 @@ func (b *Bot) answerGH(
 	if err != nil {
 		return xerrors.Errorf("dispatch workflow: %w", err)
 	}
-
 	data, err := httputil.DumpResponse(resp.Response, true)
 	if err != nil {
 		return xerrors.Errorf("dump response: %w", err)
 	}
-
 	if _, err := send.StyledText(ctx, styling.Pre(string(data), "")); err != nil {
 		return xerrors.Errorf("send: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gotd/bot
 go 1.15
 
 require (
+	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/cockroachdb/pebble v0.0.0-20201130172119-f19faf8529d6
 	github.com/dustin/go-humanize v1.0.0
 	github.com/google/go-github/v33 v33.0.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bradleyfalzon/ghinstallation v1.1.1 h1:pmBXkxgM1WeF8QYvDLT5kuQiHMcmf+X015GI0KM/E3I=
+github.com/bradleyfalzon/ghinstallation v1.1.1/go.mod h1:vyCmHTciHx/uuyN82Zc3rXN3X2KTK8nUTCrTMwAhcug=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -78,6 +80,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -160,6 +163,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
+github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=


### PR DESCRIPTION
Parses `GITHUB_PRIVATE_KEY` and `GITHUB_APP_ID` from env. On each `/github` command generates one-time installation token (that’s fine since tokens are short-lived and we are under high load).

Also the `/github` command must be a reply to a message (added `replyto` input to dispatch event payload).
